### PR TITLE
Use DVR v0.1.4

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,3 @@
 github "danthorpe/ValueCoding"
 github "antitypical/Result" >= 0.6
 github "SwiftyJSON/SwiftyJSON"
-github "danthorpe/DVR" "DVR_27_restore_print_and_abort"

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,0 +1,1 @@
+github "venmo/DVR" ~> 0.1.3

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "danthorpe/DVR" "f0195d81d27a7d7633bd8c89ac7baa986fe8a21f"
+github "venmo/DVR" "v0.1.4"
 github "antitypical/Result" "0.6.0-beta.6"
 github "SwiftyJSON/SwiftyJSON" "2.3.1"
 github "danthorpe/ValueCoding" "1.1.0"


### PR DESCRIPTION
Also moves DVR declaration to Cartfile.private. This way, developers who use Money via Carthage will not build DVR on `carthage update` (since it's not required for Money, but only required for Money-Tests