### PR TITLE
Minor Units

### DIFF
--- a/Money/Money.swift
+++ b/Money/Money.swift
@@ -117,6 +117,20 @@ public struct _Money<C: CurrencyType>: MoneyType {
     public init(floatLiteral value: FloatLiteralType) {
         decimal = _Decimal<DecimalNumberBehavior>(floatLiteral: value)
     }
+    
+    /**
+     Initialize a new value using the minorUnit to construct the final value.
+     
+     Minor units are the smallest unit for the denomination. (ex. Cents -> USD)
+     
+     - parameter minorUnit: a `IntegerLiteralType` for the system, probably `Int`.
+     */
+    public init(minorUnit: IntegerLiteralType) {
+        let digits = pow(Double(10), Double(Currency.scale))
+        let value = Double(minorUnit) / digits
+        
+        decimal = _Decimal<DecimalNumberBehavior>(floatLiteral: value)
+    }
 
     /**
      Subtract a matching `_Money<C>` from the receiver.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,20 @@ let money = pounds + euros
 
 Of course, `Money` supports the usual suspects of decimal arithmetic operators, so you can add, subtract, multiply, divide values of the same type, and values with `Int` and `Double` with the expected limitations.
 
+## Currency Minor Units
+
+You can also initialize `Money` using the smallest units available to any currency
+
+```swift
+let dollars = USD(minorUnit: 3250)
+let yuen = JPY(minorUnit: 3000)
+let bitcoin = BTC(minorUnit: 5000)
+
+print(“You have \(dollars), \(yuen) and \(bitcoin) Satoshis”)
+```
+
+> You have $ 32.50, JP¥ 3,000 and 0.00005 Satoshis
+
 ## Foreign Currency Exchange (FX)
 To represent a foreign exchange transaction, i.e. converting `USD` to `EUR`, use a FX service provider. There is built in support for [Yahoo](https://finance.yahoo.com/currency-converter/#from=USD;to=EUR;amt=1) and [OpenExchangeRates.org](https://openexchangerates.org) services. But it’s possible for consumers to create their own too.
 

--- a/Tests/MoneyTests.swift
+++ b/Tests/MoneyTests.swift
@@ -294,4 +294,45 @@ class MoneyValueCodingTests: XCTestCase {
     }
 }
 
+class MoneyMinorUnitTests: XCTestCase {
+    
+    func test__money_with_USD_minor_amount() {
+        let money = USD(minorUnit: 3000)
+        
+        XCTAssertEqual(money, 30)
+    }
+    
+    func test__money_with_USD_minor_amount_equality() {
+        let moneyFromMinorUnit = USD(minorUnit: 3000)
+        let money: USD = 30
+        
+        XCTAssertEqual(money, moneyFromMinorUnit)
+    }
+    
+    func test__money_with_JPY_minor_amount() {
+        let money = JPY(minorUnit: 3000)
+        
+        XCTAssertEqual(money, 3000)
+    }
+    
+    func test__money_with_JPY_minor_amount_equality() {
+        let moneyFromMinorUnit = JPY(minorUnit: 3000)
+        let money: JPY = 3000
+        
+        XCTAssertEqual(money, moneyFromMinorUnit)
+    }
+    
+    func test__money_with_BTC_minor_amount() {
+        let moneyFromMinorUnit = BTC(minorUnit: 3000)
+        
+        XCTAssertEqual(moneyFromMinorUnit, 0.00003)
+    }
+    
+    func test__money_with_BTC_minor_amount_equality() {
+        let moneyFromMinorUnit = BTC(minorUnit: 3000)
+        let money: BTC = 0.00003
+        
+        XCTAssertEqual(money, moneyFromMinorUnit)
+    }
+}
 

--- a/Tests/MoneyTests.swift
+++ b/Tests/MoneyTests.swift
@@ -296,28 +296,16 @@ class MoneyValueCodingTests: XCTestCase {
 
 class MoneyMinorUnitTests: XCTestCase {
     
-    func test__money_with_USD_minor_amount() {
-        let money = USD(minorUnit: 3000)
-        
-        XCTAssertEqual(money, 30)
-    }
-    
     func test__money_with_USD_minor_amount_equality() {
-        let moneyFromMinorUnit = USD(minorUnit: 3000)
-        let money: USD = 30
+        let moneyFromMinorUnit = USD(minorUnit: 3250)
+        let money: USD = 32.50
         
         XCTAssertEqual(money, moneyFromMinorUnit)
     }
     
-    func test__money_with_JPY_minor_amount() {
-        let money = JPY(minorUnit: 3000)
-        
-        XCTAssertEqual(money, 3000)
-    }
-    
     func test__money_with_JPY_minor_amount_equality() {
-        let moneyFromMinorUnit = JPY(minorUnit: 3000)
-        let money: JPY = 3000
+        let moneyFromMinorUnit = JPY(minorUnit: 2170)
+        let money: JPY = 2170
         
         XCTAssertEqual(money, moneyFromMinorUnit)
     }


### PR DESCRIPTION
First off, awesome work!

Second, I added an initializer to construct a Money object with minor units, updated the ReadMe with examples and added unit tests.

This is especially useful using with Stripe as it uses the smallest denomination in it's API.