### PR TITLE
Currency is truncated

### DIFF
--- a/Money/Shared/Currency.swift
+++ b/Money/Shared/Currency.swift
@@ -249,7 +249,9 @@ public struct Currency {
             let symbol = locale.currencySymbol
             
             let fmtr = NSNumberFormatter()
+            fmtr.numberStyle = .CurrencyStyle
             fmtr.locale = locale
+            fmtr.currencyCode = code
             
             let scale = fmtr.maximumFractionDigits            
             self.init(code: code, scale: scale, symbol: symbol)

--- a/Tests/Shared/MoneyTests.swift
+++ b/Tests/Shared/MoneyTests.swift
@@ -250,6 +250,7 @@ class MoneyDescriptionTests: MoneyTests {
 
     override func setUp() {
         super.setUp()
+        money = 3.99
         gbp = 100
         usd = 99
         cad = 102.01
@@ -257,6 +258,10 @@ class MoneyDescriptionTests: MoneyTests {
         eur = 249.499
         jpy = 32_000
         btc = 0.002_007
+    }
+
+    func test__money_description() {
+        XCTAssertEqual(money.description.endIndex, money.description.rangeOfString("3.99")?.endIndex)
     }
 
     func test__gbp_description() {


### PR DESCRIPTION
Hello,

I have a double value of 3.99 for example, and Money displays £3.
Any ideas?

```
let money = Money(availability.lowestPrice.doubleValue)
                    
let buttonString = "\(money) \(availability.buyacion)"
```