### PR TITLE
Fix issue with #available for locale

### DIFF
--- a/Money/Shared/Locale.swift
+++ b/Money/Shared/Locale.swift
@@ -62,15 +62,15 @@ internal extension NSLocale {
 
     /// - returns: a String? for the currency code.
     var money_currencyCode: String {
-        guard #available(iOSApplicationExtension 10.0, OSXApplicationExtension 10.12, *) else {
+        guard #available(iOS 10.0, iOSApplicationExtension 10.0, OSXApplicationExtension 10.12, *) else {
             return objectForKey(NSLocaleCurrencyCode) as! String
         }
-        return currencyCode
+        return currencyCode!
     }
 
     /// - returns: a String? for the currency symbol.
     var money_currencySymbol: String {
-        guard #available(iOSApplicationExtension 10.0, OSXApplicationExtension 10.12, *) else {
+        guard #available(iOS 10.0, iOSApplicationExtension 10.0, OSXApplicationExtension 10.12, *) else {
             return objectForKey(NSLocaleCurrencySymbol) as! String
         }
         return currencySymbol


### PR DESCRIPTION
`iOS 10` is required, and the optional for currencyCode should be force
unwrapped.

These changes were required for my project to compile with Swift 2.3.